### PR TITLE
bundle install で ffi がインストールできなくて暫定対応

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -52,3 +52,5 @@ end
 
 # Windows does not include zoneinfo files, so bundle the tzinfo-data gem
 gem 'tzinfo-data', platforms: [:mingw, :mswin, :x64_mingw, :jruby]
+
+gem 'ffi', '1.9.18'

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -64,7 +64,7 @@ GEM
     crass (1.0.3)
     erubi (1.7.0)
     execjs (2.7.0)
-    ffi (1.9.21)
+    ffi (1.9.18)
     globalid (0.4.1)
       activesupport (>= 4.2.0)
     i18n (0.9.5)
@@ -178,6 +178,7 @@ DEPENDENCIES
   byebug
   capybara (~> 2.13)
   coffee-rails (~> 4.2)
+  ffi (= 1.9.18)
   jbuilder (~> 2.5)
   listen (>= 3.0.5, < 3.2)
   puma (~> 3.7)


### PR DESCRIPTION
エラーがでたので対応。

```
$ bundle install --path vendor/bundler                     
```
```
Warning: the running version of Bundler (1.15.1) is older than the version that created the lockfile (1.16.0). We suggest you upgrade to the latest version of Bundler by running `gem install bundler`.
Fetching gem metadata from https://rubygems.org/............
Fetching version metadata from https://rubygems.org/...
Fetching dependency metadata from https://rubygems.org/..
Fetching rake 12.3.0
Installing rake 12.3.0
Fetching concurrent-ruby 1.0.5
Installing concurrent-ruby 1.0.5
Fetching minitest 5.11.3
Installing minitest 5.11.3
Fetching thread_safe 0.3.6
Installing thread_safe 0.3.6
Fetching builder 3.2.3
Installing builder 3.2.3
Fetching erubi 1.7.0
Installing erubi 1.7.0
Fetching mini_portile2 2.3.0
Installing mini_portile2 2.3.0
Fetching crass 1.0.3
Installing crass 1.0.3
Fetching rack 2.0.4
Installing rack 2.0.4
Fetching nio4r 2.2.0
Installing nio4r 2.2.0 with native extensions
Fetching websocket-extensions 0.1.3
Installing websocket-extensions 0.1.3
Fetching mini_mime 1.0.0
Installing mini_mime 1.0.0
Fetching arel 8.0.0
Installing arel 8.0.0
Fetching method_source 0.9.0
Installing method_source 0.9.0
Fetching thor 0.20.0
Installing thor 0.20.0
Using bundler 1.15.1
Fetching sqlite3 1.3.13
Installing sqlite3 1.3.13 with native extensions
Fetching puma 3.11.2
Installing puma 3.11.2 with native extensions
Fetching rb-fsevent 0.10.2
Installing rb-fsevent 0.10.2
Fetching ffi 1.9.21
Installing ffi 1.9.21 with native extensions
Fetching tilt 2.0.8
Installing tilt 2.0.8
Fetching execjs 2.7.0
Installing execjs 2.7.0
Fetching coffee-script-source 1.12.2
Installing coffee-script-source 1.12.2
Fetching turbolinks-source 5.1.0
Installing turbolinks-source 5.1.0
Fetching multi_json 1.13.1
Installing multi_json 1.13.1
Fetching byebug 10.0.0
Installing byebug 10.0.0 with native extensions
Fetching public_suffix 3.0.2
Installing public_suffix 3.0.2
Fetching rubyzip 1.2.1
Installing rubyzip 1.2.1
Fetching bindex 0.5.0
Installing bindex 0.5.0 with native extensions
Fetching ruby_dep 1.5.0
Installing ruby_dep 1.5.0
Fetching i18n 0.9.5
Installing i18n 0.9.5
Fetching tzinfo 1.2.5
Installing tzinfo 1.2.5
Fetching nokogiri 1.8.2
Installing nokogiri 1.8.2 with native extensions
  7
Fetching rack-test 0.8.2
Installing rack-test 0.8.2
Fetching sprockets 3.7.1
Installing sprockets 3.7.1
Fetching websocket-driver 0.6.5
Installing websocket-driver 0.6.5 with native extensions
Fetching mail 2.7.0
Installing mail 2.7.0
The latest bundler is 1.16.1, but you are currently running 1.15.1.
To update, run `gem install bundler`
Gem::Ext::BuildError: ERROR: Failed to build gem native extension.

    current directory: /Users/kseta/.ghq/github.com/shokola/ticket-san/vendor/bundler/ruby/2.4.0/gems/ffi-1.9.21/ext/ffi_c
/Users/kseta/.rbenv/versions/2.4.1/bin/ruby -r ./siteconf20180217-20200-f4jkls.rb extconf.rb
checking for ffi.h... no
checking for ffi.h in /usr/local/include,/usr/include/ffi... no
checking for shlwapi.h... no
checking for rb_thread_blocking_region()... no
checking for rb_thread_call_with_gvl()... yes
checking for rb_thread_call_without_gvl()... yes
creating extconf.h
creating Makefile

current directory: /Users/kseta/.ghq/github.com/shokola/ticket-san/vendor/bundler/ruby/2.4.0/gems/ffi-1.9.21/ext/ffi_c
make "DESTDIR=" clean

current directory: /Users/kseta/.ghq/github.com/shokola/ticket-san/vendor/bundler/ruby/2.4.0/gems/ffi-1.9.21/ext/ffi_c
make "DESTDIR="
Running autoreconf for libffi
autoreconf: Entering directory `.'
autoreconf: configure.ac: not using Gettext
autoreconf: running: aclocal -I m4 --output=aclocal.m4t
Can't exec "aclocal": No such file or directory at /usr/local/Cellar/autoconf/2.69/share/autoconf/Autom4te/FileUtils.pm line 326.
autoreconf: failed to run aclocal: No such file or directory
make: *** ["/Users/kseta/.ghq/github.com/shokola/ticket-san/vendor/bundler/ruby/2.4.0/gems/ffi-1.9.21/ext/ffi_c/libffi-x86_64-darwin16"/.libs/libffi_convenience.a] Error 1

make failed, exit code 2

Gem files will remain installed in /Users/kseta/.ghq/github.com/shokola/ticket-san/vendor/bundler/ruby/2.4.0/gems/ffi-1.9.21 for inspection.
Results logged to /Users/kseta/.ghq/github.com/shokola/ticket-san/vendor/bundler/ruby/2.4.0/extensions/x86_64-darwin-16/2.4.0-static/ffi-1.9.21/gem_make.out

An error occurred while installing ffi (1.9.21), and Bundler cannot continue.
Make sure that `gem install ffi -v '1.9.21'` succeeds before bundling.

In Gemfile:
  sass-rails was resolved to 5.0.7, which depends on
    sass was resolved to 3.5.5, which depends on
      sass-listen was resolved to 4.0.0, which depends on
        rb-inotify was resolved to 0.9.10, which depends on
          ffi
```