### PR TITLE
トップページのルーティングを追加

### DIFF
--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
   resources :tickets, only: [:new, :create, :show, :edit, :update]
+
+  root to: 'tickets#index'
   # For details on the DSL available within this file, see http://guides.rubyonrails.org/routing.html
 end


### PR DESCRIPTION
fix #1 

## スクリーンショット

<img width="640" alt="ticketsan" src="https://user-images.githubusercontent.com/1487865/36339562-1a299112-140c-11e8-9777-a93b9acecb74.png">

## rails routes

```
     Prefix Verb  URI Pattern                 Controller#Action
    tickets POST  /tickets(.:format)          tickets#create
 new_ticket GET   /tickets/new(.:format)      tickets#new
edit_ticket GET   /tickets/:id/edit(.:format) tickets#edit
     ticket GET   /tickets/:id(.:format)      tickets#show
            PATCH /tickets/:id(.:format)      tickets#update
            PUT   /tickets/:id(.:format)      tickets#update
       root GET   /                           tickets#index
```