### PR TITLE
チケットのバリデーションで空文字を弾く・ステータスの値をチェック

### DIFF
--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,5 +1,4 @@
 class Ticket < ApplicationRecord
   validates :title, presence: true
   validates :status, presence: true, inclusion: ['todo', 'doing', 'done']
-  validates :assignee, presence: true
 end

--- a/app/models/ticket.rb
+++ b/app/models/ticket.rb
@@ -1,2 +1,5 @@
 class Ticket < ApplicationRecord
+  validates :title, presence: true
+  validates :status, presence: true, inclusion: ['todo', 'doing', 'done']
+  validates :assignee, presence: true
 end


### PR DESCRIPTION
## 変更点

1. フォームサブミットすると空文字が登録されてしまうため、バリデーションを追加した。
2. ステータスが `todo`, `doing`, `done` のみ登録できるよう、バリデーションを追加した。

## スクリーンショット

<img width="507" alt="ticketsan" src="https://user-images.githubusercontent.com/1487865/36339693-92de42ae-140e-11e8-8352-95b7d0d44a5d.png">
